### PR TITLE
[FIX] Bad variable name

### DIFF
--- a/playbooks/kube-master-playbook.yml
+++ b/playbooks/kube-master-playbook.yml
@@ -40,4 +40,4 @@
       register: command_result
       failed_when: 
         - '"taint \"node-role.kubernetes.io/master\" not found" not in command_result.stderr'
-        - result.rc != 0
+        - command_result.rc != 0


### PR DESCRIPTION
# Purpose of this PR
There is issue on the `Untaint master` task in the master's playbook -> use the correct variable name.