### PR TITLE
feat: Proxmox Infrastructure as Code

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,7 @@ export SSH_KNOWN_HOSTS=/dev/null
 export TAILSCALE_KEY=tskey-auth-***********************
 
 export BIN_DIR="$HOME/.rd/bin"
+
+# Terraform S3 backend requires AWS_* env vars (Scaleway is S3-compatible)
+export AWS_ACCESS_KEY_ID=$(scw config get access-key)
+export AWS_SECRET_ACCESS_KEY=$(scw config get secret-key)

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ SHA256*
 *.kubeconfig.yaml
 **/k0s_backup*
 **/__pycache__/
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -24,3 +24,19 @@ workers:
         type: NTFS
     oracle-arm:
       is_raspberry: false
+
+proxmox:
+  hosts:
+    jonbonas:
+      # No ansible_host: resolved via tailscale-hostmap (like brassberry hosts)
+      ansible_ssh_user: root
+      is_raspberry: false
+      # ZFS pool devices -- update after install based on lsblk output
+      fastpool_device: /dev/nvme1n1
+      # List HDD devices for tank pool. RAIDZ2 with 4 disks, RAIDZ1 with 3.
+      tank_devices:
+        - /dev/sda
+        - /dev/sdb
+        - /dev/sdc
+        - /dev/sdd
+      tank_vdev_type: raidz1

--- a/playbooks/proxmox-bootstrap.yaml
+++ b/playbooks/proxmox-bootstrap.yaml
@@ -1,0 +1,82 @@
+#################################################
+# Bootstrap Proxmox after community post-install script
+# Run "make proxmox-post-install" first!
+#
+# This handles what the community script does NOT:
+# - Useful packages
+# - Tailscale
+# - Terraform API token
+#
+# ZFS config (including rpool tuning) is in proxmox-zfs.yaml
+#################################################
+---
+- hosts: proxmox
+  become: true
+  tasks:
+    # =========================================
+    # Packages
+    # =========================================
+    - name: Install useful packages
+      apt:
+        name:
+          - vim
+          - htop
+          - iotop
+          - tmux
+          - curl
+          - wget
+          - sudo
+        state: present
+        update_cache: yes
+
+    # =========================================
+    # Tailscale
+    # =========================================
+    - name: Check if Tailscale is installed
+      command: which tailscale
+      register: tailscale_check
+      failed_when: false
+      changed_when: false
+
+    - name: Install Tailscale
+      shell: curl -fsSL https://tailscale.com/install.sh | sh
+      when: tailscale_check.rc != 0
+
+    - name: Reminder to join Tailscale
+      debug:
+        msg: "Tailscale installed. Run 'tailscale up' on the host to join your tailnet."
+      when: tailscale_check.rc != 0
+
+    # =========================================
+    # Terraform API token
+    # =========================================
+    - name: Check if terraform user exists
+      command: pveum user list --output-format json
+      register: pveum_users
+      changed_when: false
+
+    - name: Create terraform API user
+      command: pveum user add terraform@pam --comment "Terraform automation"
+      when: "'terraform@pam' not in pveum_users.stdout"
+
+    - name: Grant Administrator role to terraform user
+      command: pveum aclmod / -user terraform@pam -role Administrator
+      when: "'terraform@pam' not in pveum_users.stdout"
+
+    - name: Check if terraform token exists
+      command: pveum user token list terraform@pam --output-format json
+      register: pveum_tokens
+      changed_when: false
+      failed_when: false
+
+    - name: Create terraform API token
+      command: pveum user token add terraform@pam terraform-token --privsep 0 --output-format json
+      register: terraform_token
+      when: "'terraform-token' not in pveum_tokens.stdout"
+
+    - name: Display terraform API token
+      debug:
+        msg: >
+          Save this token in your terraform.tfvars:
+          proxmox_api_token = "terraform@pam!terraform-token={{ (terraform_token.stdout | from_json).value }}"
+      when: terraform_token is changed

--- a/playbooks/proxmox-zfs.yaml
+++ b/playbooks/proxmox-zfs.yaml
@@ -1,0 +1,91 @@
+#################################################
+# Configure ALL ZFS pools and datasets on Proxmox
+# - rpool: NVMe 1TB OS pool (tuning only, created by installer)
+# - fastpool: NVMe 2TB (single disk, lz4)
+# - tank: HDDs (RAIDZ1 or RAIDZ2, zstd)
+# - Datasets with tuned properties
+#
+# Requires: community.general >= 11.0.0
+#   ansible-galaxy collection install community.general
+#################################################
+---
+- hosts: proxmox
+  become: true
+  tasks:
+    #############################
+    # rpool: NVMe 1TB OS pool (tuning only)
+    #############################
+    - name: Enable lz4 compression on rpool
+      community.general.zfs:
+        name: rpool
+        state: present
+        extra_zfs_properties:
+          compression: lz4
+          atime: "off"
+
+    #############################
+    # fastpool: NVMe 2TB
+    #############################
+    - name: Create fastpool (NVMe 2TB performance pool)
+      community.general.zpool:
+        name: fastpool
+        force: true
+        vdevs:
+          - disks:
+              - "{{ fastpool_device }}"
+        pool_properties:
+          ashift: "12"
+          autoexpand: "on"
+        filesystem_properties:
+          compression: lz4
+          atime: "off"
+          xattr: sa
+          dnodesize: auto
+
+    - name: Create fastpool datasets
+      community.general.zfs:
+        name: "fastpool/{{ item }}"
+        state: present
+      loop:
+        - vm-disks
+        - ct-data
+
+    #############################
+    # tank: HDDs (RAIDZ1 or RAIDZ2)
+    #############################
+    - name: Create tank (HDD capacity + backup pool)
+      community.general.zpool:
+        name: tank
+        force: true
+        vdevs:
+          - type: "{{ tank_vdev_type }}"
+            disks: "{{ tank_devices }}"
+        pool_properties:
+          ashift: "12"
+          autoexpand: "on"
+        filesystem_properties:
+          compression: zstd
+          atime: "off"
+          xattr: sa
+          dnodesize: auto
+
+    # Large-file datasets: 1M recordsize for better HDD performance
+    - name: Create tank large-file datasets
+      community.general.zfs:
+        name: "tank/{{ item }}"
+        state: present
+        extra_zfs_properties:
+          recordsize: "1M"
+      loop:
+        - backups
+        - media
+        - iso
+
+    # Standard datasets: default 128K recordsize
+    - name: Create tank standard datasets
+      community.general.zfs:
+        name: "tank/{{ item }}"
+        state: present
+      loop:
+        - templates
+        - data

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -1,0 +1,127 @@
+# Proxmox Infrastructure as Code
+
+Manages the Proxmox VE homelab server `jonbonas` using:
+
+- **Ansible** for OS-level configuration (repos, packages, ZFS pools, datasets)
+- **Terraform** (bpg/proxmox) for Proxmox API resources (storage defs, VMs, users)
+
+Networking: steps 1-3 use the local IP (`192.168.1.30`). After joining the
+Tailscale network, all subsequent commands use the hostname `jonbonas` (resolved
+via [tailscale-hostmap](https://github.com/mxbi/tailscale-hostmap)).
+
+## Hardware
+
+| Component | Device | Size | Purpose |
+|-----------|--------|------|---------|
+| NVMe 1TB | Crucial CT1000P3PSSD8 | 931 GB | Proxmox OS (`rpool`, ZFS RAID0) |
+| NVMe 2TB | Crucial CT2000P3PSSD8 | 1.8 TB | Performance workloads (`fastpool`) |
+| HDDs 3-4x | Seagate ST12000NM0127 | 12 TB each | Capacity + backups (`tank`, RAIDZ1/2) |
+
+## Prerequisites
+
+- Ansible with `community.general` collection >= 11.0.0
+- Terraform >= 1.14.5
+- SSH key access to `root@192.168.1.30` (initial) then `root@jonbonas` (Tailscale)
+- Scaleway account with Object Storage bucket for Terraform state
+
+```bash
+# Install Ansible collection
+ansible-galaxy collection install community.general
+
+# Scaleway CLI must be configured (credentials used by .envrc for Terraform S3 backend)
+scw init
+```
+
+## Setup Steps
+
+### 1. Install Proxmox (local IP: 192.168.1.30)
+
+Install Proxmox VE 9.1 from USB key on the NVMe 1TB with ZFS (RAID0).
+
+- Hostname: `jonbonas.local`
+- IP: `192.168.1.30/24`
+- Gateway: `192.168.1.1`
+
+Then set up SSH key access:
+
+```bash
+ssh-keygen -R 192.168.1.30
+ssh-copy-id root@192.168.1.30
+```
+
+### 2. Run Community Post-Install Script (local IP)
+
+```bash
+make proxmox-post-install
+```
+
+### 3. Run Ansible Bootstrap (local IP)
+
+Installs packages, tunes rpool, installs Tailscale, creates Terraform API token:
+
+```bash
+make proxmox-bootstrap
+```
+
+Save the API token output for `terraform.tfvars`.
+
+### 4. Join Tailscale and Update Hosts (transition to Tailscale)
+
+```bash
+# On the Proxmox host (via local IP)
+ssh root@192.168.1.30 tailscale up
+
+# On your Mac -- update /etc/hosts with Tailscale IPs
+make tailscale-hosts
+
+# Verify: jonbonas should now resolve
+ssh jonbonas hostname
+```
+
+From this point on, all commands use the Tailscale hostname `jonbonas`.
+
+### 5. Run Ansible ZFS Setup (Tailscale)
+
+Creates ZFS pools (`fastpool`, `tank`) and all datasets:
+
+```bash
+make proxmox-zfs
+```
+
+Before running, verify `hosts.yaml` has the correct devices:
+- `fastpool_device`: the NVMe 2TB device path
+- `tank_devices`: list of HDD device paths
+- `tank_vdev_type`: `raidz1` (3 disks) or `raidz2` (4+ disks)
+
+### 6. Run Terraform (Tailscale)
+
+```bash
+cd proxmox/terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values (API token from step 3, SSH key)
+
+terraform init
+terraform plan
+terraform apply
+```
+
+The `import` blocks in `users.tf` will automatically import the Ansible-created
+terraform user, token, and ACL on the first apply.
+
+## ZFS Architecture
+
+See **[ZFS.md](ZFS.md)** for a full explanation of ZFS concepts, architecture
+diagrams, why each choice was made, and how to expand storage later.
+
+Quick summary: 3 pools, 3 purposes.
+
+| Pool | Disk(s) | Redundancy | Purpose |
+|------|---------|------------|---------|
+| `rpool` | NVMe 1TB | Single | Proxmox OS (rebuildable from code) |
+| `fastpool` | NVMe 2TB | Single | VM disks, K8s workloads (rebuildable) |
+| `tank` | 4x HDD 12TB | RAIDZ1 | Backups, media, data (survives 1 disk failure, ~36TB usable) |
+
+## Future: Enable Proxmox Backup Server
+
+Uncomment the PBS LXC in `terraform/containers.tf` and run `terraform apply`.
+See the comments in that file for prerequisites.

--- a/proxmox/ZFS.md
+++ b/proxmox/ZFS.md
@@ -1,0 +1,255 @@
+# ZFS Architecture -- Why and How
+
+This document explains the ZFS concepts behind our Proxmox storage setup,
+why each choice was made, and how the pieces fit together.
+
+Reference: [ZFS for Dummies](https://ikrima.dev/dev-notes/homelab/zfs-for-dummies/)
+
+---
+
+## ZFS in 5 Minutes
+
+ZFS is both a **filesystem** (like ext4 or NTFS) and a **volume manager**
+(like LVM) rolled into one. It handles disks, RAID, checksums, compression,
+and snapshots -- all in a single layer.
+
+### The 3 Layers
+
+```
+┌──────────────────────────────────────────┐
+│              Datasets                    │  <- filesystems you actually use
+│   (compression, snapshots, quotas...)    │     like folders with superpowers
+├──────────────────────────────────────────┤
+│              Pool (zpool)                │  <- groups vdevs into one storage
+│   (aggregates space from vdevs)          │     namespace, like a big bucket
+├──────────────────────────────────────────┤
+│              vdevs                       │  <- groups of disks with redundancy
+│   (single, mirror, raidz1, raidz2...)   │     this is where RAID happens
+└──────────────────────────────────────────┘
+```
+
+**vdev** (virtual device): One or more physical disks grouped together.
+The redundancy level is set here -- a single disk, a mirror, or RAIDZ.
+Once a vdev is created, you cannot change its type or remove disks from it.
+
+**Pool** (zpool): One or more vdevs combined. The pool stripes data across
+its vdevs. All space from all vdevs is available to all datasets in the pool.
+You can add vdevs to a pool later to grow it.
+
+**Dataset**: A filesystem inside a pool. Datasets inherit properties from
+their parent (pool or parent dataset) but can override them. Each dataset
+can have its own compression, record size, snapshots, etc. Datasets are
+cheap to create -- they share the pool's space dynamically (no pre-allocation).
+
+### RAIDZ Levels (our choices)
+
+| Type | Min disks | Can lose | Usable space (4 disks) | Use case |
+|------|-----------|----------|------------------------|----------|
+| Single | 1 | 0 | 100% | Performance, replaceable data |
+| Mirror | 2 | N-1 | 50% | Max redundancy |
+| RAIDZ1 | 3 | 1 | 75% (3 of 4) | Good balance, small arrays |
+| **RAIDZ1** | **3** | **1** | **75% (3 of 4)** | **Our choice: good balance** |
+| RAIDZ3 | 5 | 3 | 40% | Very large arrays |
+
+**Why RAIDZ1 for our HDDs?** With 4 disks, RAIDZ1 gives us 75% usable space
+(~36TB) vs 50% with RAIDZ2 (~24TB). We accept the risk of losing data if
+2 disks fail simultaneously during a rebuild. Mitigations: regular backups
+to external/cloud, and the plan to add more disks later (a second vdev can
+use RAIDZ2 for better redundancy as the array grows).
+
+### Key Properties
+
+| Property | What it does | Our choices |
+|----------|-------------|-------------|
+| `compression` | Compresses data transparently | `lz4` (fast, NVMe) / `zstd` (better ratio, HDDs) |
+| `atime` | Updates access time on every read | `off` -- saves tons of writes |
+| `recordsize` | Block size for files | `128K` default / `1M` for large files |
+| `ashift` | Sector size alignment (2^n) | `12` = 4K sectors (matches modern disks) |
+| `xattr=sa` | Store extended attributes in inodes | Faster than default (saves a lookup) |
+| `dnodesize=auto` | Let ZFS pick optimal dnode size | Better for xattr=sa |
+| `autoexpand` | Pool grows if disks are replaced with larger ones | `on` |
+
+**Why lz4 vs zstd?**
+- `lz4`: Nearly zero CPU cost, slight compression. Perfect for NVMe where
+  latency matters more than space.
+- `zstd`: Better compression ratio but uses more CPU. Worth it on HDDs
+  where the bottleneck is disk I/O, not CPU. Compressing data means fewer
+  bytes to read/write on slow spinning disks.
+
+**Why recordsize=1M for some datasets?**
+ZFS reads/writes in blocks of `recordsize`. For large files (ISOs, backups,
+media), using 1M blocks means fewer metadata operations and sequential I/O
+patterns that HDDs love. For small files or databases, the default 128K
+(or even smaller) is better to avoid wasting space.
+
+---
+
+## Our Architecture
+
+```
+                         jonbonas (Proxmox VE)
+    ┌────────────────────────────────────────────────────────────────┐
+    │                                                                │
+    │   NVMe 1TB (OS)         NVMe 2TB             4x HDD 12TB     │
+    │   ┌───────────┐         ┌───────────┐        ┌─────────────┐  │
+    │   │  single   │         │  single   │        │   RAIDZ1    │  │
+    │   │   vdev    │         │   vdev    │        │    vdev     │  │
+    │   └─────┬─────┘         └─────┬─────┘        │ ┌─┬──┬──┐  │  │
+    │         │                     │              │ │a│b │c │d │  │
+    │         │                     │              └─┴─┴──┴──┴──┘  │
+    │   ┌─────┴─────┐         ┌─────┴─────┐        ┌─────┴──────┐  │
+    │   │   rpool   │         │ fastpool  │        │    tank    │  │
+    │   │ (pool)    │         │ (pool)    │        │   (pool)   │  │
+    │   └─────┬─────┘         └─────┬─────┘        └─────┬──────┘  │
+    │         │                     │                    │         │
+    │         │               ┌─────┴─────┐        ┌─────┴──────┐  │
+    │    Proxmox OS           │ vm-disks  │        │ backups    │  │
+    │    (root, swap,         │ ct-data   │        │ media      │  │
+    │     boot, etc.)         └───────────┘        │ iso        │  │
+    │                          lz4 / 128K          │ templates  │  │
+    │    lz4 / atime=off                           │ data       │  │
+    │                                              └────────────┘  │
+    │                                               zstd / mixed   │
+    │                                               recordsizes    │
+    └────────────────────────────────────────────────────────────────┘
+```
+
+### 3 Pools, 3 Purposes
+
+| Pool | Disk(s) | Redundancy | Compression | Role |
+|------|---------|------------|-------------|------|
+| `rpool` | NVMe 1TB | None (single) | lz4 | **OS only.** Created by Proxmox installer. We just tune properties. Losing this = reinstall Proxmox (15 min). |
+| `fastpool` | NVMe 2TB | None (single) | lz4 | **VM/container workloads.** Fast storage for K8s workers. Losing this = re-create VMs from code (Terraform + cloud-init). |
+| `tank` | 4x HDD 12TB | RAIDZ1 | zstd | **Bulk storage + backups.** Survives 1 disk failure (~36TB usable). Plan to add vdevs later. |
+
+### Why 3 Separate Pools (not 1 big pool)?
+
+A pool stripes data across all its vdevs. If we put NVMe and HDD vdevs
+in the same pool, ZFS would write data to both, and the HDDs would become
+the bottleneck for everything. Separate pools let us:
+
+1. **Match speed to workload**: VMs on NVMe, archives on HDD
+2. **Isolate failure domains**: A dead HDD doesn't affect VM performance
+3. **Use different compression**: lz4 for latency, zstd for space
+4. **Tune recordsize per use case**: 128K for VMs, 1M for large files
+
+### Why No Redundancy on NVMe Pools?
+
+- `rpool` (OS): A reinstall from USB takes 15 minutes. All config is in
+  Ansible/Terraform -- the entire state can be rebuilt from code.
+- `fastpool` (VMs): VMs are created by Terraform with cloud-init. K8s state
+  is in etcd on the Raspberry Pi cluster. Nothing on fastpool is unique.
+
+Redundancy costs 50%+ of your NVMe space. For data that can be rebuilt
+from code in minutes, it's not worth it. Spend the redundancy budget on
+`tank` where irreplaceable data lives.
+
+### Dataset Layout
+
+```
+rpool/                          # Proxmox OS (installer-created)
+├── ROOT/pve-1                  # Root filesystem
+├── data                        # LXC/VM storage (default)
+└── ...                         # (managed by Proxmox)
+
+fastpool/                       # NVMe 2TB performance pool
+├── vm-disks                    # K8s worker VM disk images
+└── ct-data                     # Container volumes
+
+tank/                           # HDD capacity pool (RAIDZ1)
+├── backups      (1M rec)       # Proxmox VM/CT backups (vzdump)
+├── media        (1M rec)       # Media files (NFS/Samba share)
+├── iso          (1M rec)       # ISO images for VM installs
+├── templates    (128K rec)     # Container templates (small files)
+└── data         (128K rec)     # General-purpose storage
+```
+
+### How Data Flows
+
+```
+  Terraform creates VMs ──────> fastpool/vm-disks (NVMe, fast I/O)
+                                     │
+                                     │ vzdump backup
+                                     ▼
+                              tank/backups (HDD, compressed, redundant)
+
+  ISO downloads ──────────────> tank/iso (HDD, large files, 1M blocks)
+
+  Media / NAS shares ─────────> tank/media (HDD, zstd saves space)
+
+  Cloud-init templates ───────> tank/templates (HDD, small files)
+```
+
+---
+
+## Growing the Storage Later
+
+### Add a disk to the existing RAIDZ1 vdev (OpenZFS 2.2+)
+
+```bash
+# Example: add a 5th HDD to the existing RAIDZ1
+zpool attach tank raidz1-0 /dev/sde
+```
+
+After this, the vdev becomes a 5-disk RAIDZ1 (still lose 1 disk to parity,
+gain 1 disk of usable space). Note: existing data keeps the old parity
+ratio until rewritten.
+
+### Add a whole new vdev to the pool
+
+```bash
+# Example: add 4 new HDDs as a second vdev (can choose a different RAIDZ level)
+zpool add tank raidz2 /dev/sde /dev/sdf /dev/sdg /dev/sdh
+```
+
+This doubles the pool's capacity and throughput (ZFS stripes across vdevs).
+All datasets in `tank` automatically see the new space.
+
+### Replace a disk with a larger one
+
+```bash
+zpool replace tank /dev/sda /dev/new-disk
+# Repeat for each disk. With autoexpand=on, pool grows automatically.
+```
+
+---
+
+## Quick ZFS Commands Cheatsheet
+
+```bash
+# Pool status (health, scrub progress, errors)
+zpool status
+
+# List pools with space usage
+zpool list
+
+# List all datasets with space and mountpoints
+zfs list
+
+# Check a specific property
+zfs get compression tank
+zfs get recordsize tank/backups
+
+# Manual scrub (run monthly, checks all checksums)
+zpool scrub tank
+
+# Snapshot a dataset
+zfs snapshot tank/backups@2025-02-15
+
+# List snapshots
+zfs list -t snapshot
+
+# Send a snapshot to another pool or remote host
+zfs send tank/backups@2025-02-15 | zfs recv backup-pool/backups
+zfs send tank/backups@2025-02-15 | ssh remote zfs recv tank/backups
+```
+
+---
+
+## What Manages What
+
+| Layer | Tool | What it does |
+|-------|------|-------------|
+| Disks -> Pools -> Datasets | **Ansible** (`proxmox-zfs.yaml`) | Creates zpools, vdevs, datasets, sets all properties |
+| Pools -> Proxmox Storage | **Terraform** (`storage.tf`) | Registers pools as Proxmox storage backends |
+| Proxmox Storage -> VMs | **Terraform** (`vms.tf`) | Creates VMs on the registered storage |

--- a/proxmox/terraform/.terraform.lock.hcl
+++ b/proxmox/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.95.0"
+  constraints = "0.95.0"
+  hashes = [
+    "h1:NamnpRo4NLLqhjWFw0lPr4V0Vm/hHqNOXfCbiPsv9WY=",
+    "zh:07439b6c10c48c25357cd574d9db024adb21419865c5b22019a2d0493314b2fb",
+    "zh:29b56acca3df3d1ad1c0d677165192d59ec850c26d013e19a18cc94b11789b39",
+    "zh:35f73b7eeef23867633ee2d687c1cf015eb15ff128fc9527f018aaf0c58ef1ce",
+    "zh:4a479884f6549e8f5b11659c4fe9e3af4fc3f95440d7d8b54335d608361c731f",
+    "zh:4c89f62fb4528f15ae71fc91f792fe5e747ce162e7bf6124f21989d8805a3971",
+    "zh:510ccaaddb1add81563417dcb8f25f364988e8797293d2889b0bdbf623abe01b",
+    "zh:5d791e444e671f6b41c371fddec9d3aba8c8c5c8996ec0864b5aa8678b70feee",
+    "zh:5e655ca1b5d10cfebbe649952d073699005015082de897f3424faa80a9c13667",
+    "zh:71d639eaa7aaa7a6fa68a8bd546d864842c163ff4f2abc48176e287642156d27",
+    "zh:beb1f2ea7ca4e1e42373749b3b1a3dc7bb2bf283001eb9181e162da4f1345b07",
+    "zh:cd8116cfb4988c7157ec2ef18a3fb2bfa1020342fd66f99aa66ef8db678fe09d",
+    "zh:d0e3eacce028554d641ea7bfb857888559f9f92f3dcc00bdd5d8a3bc70768580",
+    "zh:e0eabff8250b428de253f064324fc878a27fa258a79aa76a1b0dab158986cec6",
+    "zh:eef582a3fcc21a7c7c29719ec1f969089f9bba8376a6bb0c8f5aa6c8f89a8ee0",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/proxmox/terraform/backend.tf
+++ b/proxmox/terraform/backend.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+    bucket = "dixneuf19-tfstates"
+    key    = "proxmox/terraform.tfstate"
+    region = "fr-par"
+
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+
+    # Required for S3-compatible backends (non-AWS)
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true
+  }
+}

--- a/proxmox/terraform/containers.tf
+++ b/proxmox/terraform/containers.tf
@@ -1,0 +1,71 @@
+# =============================================
+# LXC Containers
+#
+# Proxmox Backup Server (PBS) -- COMMENTED OUT
+# Uncomment when you want to enable PBS for deduplicated backups.
+# PBS provides client-side dedup, incremental backups, and a web UI.
+# Much more efficient than raw vzdump for backing up multiple similar VMs.
+#
+# Prerequisites:
+#   1. Download the PBS LXC template:
+#      pveam download tank-templates proxmox-backup-server_3.0_amd64.tar.zst
+#   2. Uncomment the resources below
+#   3. terraform apply
+# =============================================
+
+# resource "proxmox_virtual_environment_container" "pbs" {
+#   description = "Proxmox Backup Server"
+#   node_name   = var.proxmox_node
+#   vm_id       = 300
+#
+#   initialization {
+#     hostname = "pbs"
+#
+#     ip_config {
+#       ipv4 {
+#         address = "192.168.1.31/24"
+#         gateway = "192.168.1.1"
+#       }
+#     }
+#
+#     dns {
+#       servers = ["192.168.1.1", "1.1.1.1"]
+#     }
+#
+#     user_account {
+#       keys = [var.ssh_public_key]
+#     }
+#   }
+#
+#   cpu {
+#     cores = 2
+#   }
+#
+#   memory {
+#     dedicated = 2048
+#   }
+#
+#   disk {
+#     datastore_id = "local"
+#     size         = 8
+#   }
+#
+#   # Mount tank/backups into the container
+#   mount_point {
+#     volume = "/tank/backups"
+#     path   = "/mnt/backups"
+#   }
+#
+#   network_interface {
+#     name   = "eth0"
+#     bridge = "vmbr0"
+#   }
+#
+#   operating_system {
+#     template_file_id = "tank-templates:vztmpl/proxmox-backup-server_3.0_amd64.tar.zst"
+#     type             = "debian"
+#   }
+#
+#   unprivileged = true
+#   start_on_boot = true
+# }

--- a/proxmox/terraform/outputs.tf
+++ b/proxmox/terraform/outputs.tf
@@ -1,0 +1,26 @@
+# =============================================
+# Outputs
+# =============================================
+
+# output "k8s_worker_ips" {
+#   description = "IP addresses of K8s worker VMs"
+#   value = [
+#     for vm in proxmox_virtual_environment_vm.k8s_worker :
+#     "192.168.1.${40 + index(proxmox_virtual_environment_vm.k8s_worker, vm)}"
+#   ]
+# }
+
+# output "k8s_worker_names" {
+#   description = "Names of K8s worker VMs"
+#   value       = [for vm in proxmox_virtual_environment_vm.k8s_worker : vm.name]
+# }
+
+output "storage_ids" {
+  description = "Proxmox storage IDs"
+  value = {
+    fastpool       = proxmox_virtual_environment_storage_zfspool.fastpool.id
+    tank_backups   = proxmox_virtual_environment_storage_directory.tank_backups.id
+    tank_iso       = proxmox_virtual_environment_storage_directory.tank_iso.id
+    tank_templates = proxmox_virtual_environment_storage_directory.tank_templates.id
+  }
+}

--- a/proxmox/terraform/provider.tf
+++ b/proxmox/terraform/provider.tf
@@ -1,0 +1,9 @@
+provider "proxmox" {
+  endpoint  = var.proxmox_endpoint
+  api_token = var.proxmox_api_token
+  insecure  = true # Self-signed certificate
+
+  ssh {
+    agent = true
+  }
+}

--- a/proxmox/terraform/storage.tf
+++ b/proxmox/terraform/storage.tf
@@ -1,0 +1,56 @@
+# =============================================
+# Proxmox Storage Definitions
+# These register the ZFS pools (created by Ansible) as Proxmox storage
+# =============================================
+
+import {
+  to = proxmox_virtual_environment_storage_zfspool.fastpool
+  id = "fastpool"
+}
+
+import {
+  to = proxmox_virtual_environment_storage_directory.tank_backups
+  id = "tank-backups"
+}
+
+import {
+  to = proxmox_virtual_environment_storage_directory.tank_iso
+  id = "tank-iso"
+}
+
+import {
+  to = proxmox_virtual_environment_storage_directory.tank_templates
+  id = "tank-templates"
+}
+
+# fastpool -- NVMe 2TB ZFS pool for VM disks
+resource "proxmox_virtual_environment_storage_zfspool" "fastpool" {
+  id       = "fastpool"
+  zfs_pool = "fastpool/vm-disks"
+  nodes    = [var.proxmox_node]
+  content  = ["images", "rootdir"]
+}
+
+# tank/backups -- HDD pool for vzdump backups
+resource "proxmox_virtual_environment_storage_directory" "tank_backups" {
+  id      = "tank-backups"
+  path    = "/tank/backups"
+  nodes   = [var.proxmox_node]
+  content = ["backup"]
+}
+
+# tank/iso -- HDD pool for ISO images
+resource "proxmox_virtual_environment_storage_directory" "tank_iso" {
+  id      = "tank-iso"
+  path    = "/tank/iso"
+  nodes   = [var.proxmox_node]
+  content = ["iso", "import"]
+}
+
+# tank/templates -- HDD pool for container templates
+resource "proxmox_virtual_environment_storage_directory" "tank_templates" {
+  id      = "tank-templates"
+  path    = "/tank/templates"
+  nodes   = [var.proxmox_node]
+  content = ["vztmpl"]
+}

--- a/proxmox/terraform/templates.tf
+++ b/proxmox/terraform/templates.tf
@@ -1,0 +1,13 @@
+# =============================================
+# Cloud-init Ubuntu template
+# Downloads the cloud image and creates a reusable VM template
+# =============================================
+
+# Download Ubuntu 24.04 cloud image directly on the Proxmox node
+resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
+  content_type = "iso"
+  datastore_id = "local"
+  node_name    = var.proxmox_node
+  url          = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+  file_name    = "noble-server-cloudimg-amd64.img"
+}

--- a/proxmox/terraform/terraform.tfvars.example
+++ b/proxmox/terraform/terraform.tfvars.example
@@ -1,0 +1,14 @@
+# Copy this file to terraform.tfvars and fill in your values
+# terraform.tfvars is gitignored
+
+proxmox_endpoint  = "https://jonbonas:8006"
+proxmox_api_token = "terraform@pam!terraform-token=your-secret-token-here"
+proxmox_node      = "jonbonas"
+
+ssh_public_key = "ssh-ed25519 AAAA... your-key-here"
+vm_user        = "dixneuf19"
+
+k8s_worker_count     = 2
+k8s_worker_cores     = 4
+k8s_worker_memory    = 8192
+k8s_worker_disk_size = 50

--- a/proxmox/terraform/users.tf
+++ b/proxmox/terraform/users.tf
@@ -1,0 +1,48 @@
+# =============================================
+# Users, Roles, and ACLs
+#
+# The terraform@pam user and token are created by the Ansible bootstrap
+# playbook. The import blocks below bring them into Terraform state
+# automatically on the first `terraform apply`.
+# =============================================
+
+import {
+  to = proxmox_virtual_environment_user.terraform
+  id = "terraform@pam"
+}
+
+import {
+  to = proxmox_virtual_environment_user_token.terraform
+  id = "terraform@pam!terraform-token"
+}
+
+import {
+  to = proxmox_virtual_environment_acl.terraform_admin
+  id = "/?terraform@pam?Administrator"
+}
+
+resource "proxmox_virtual_environment_user" "terraform" {
+  user_id = "terraform@pam"
+  comment = "Terraform automation"
+  enabled = true
+
+  lifecycle {
+    # ACL is returned inline by the API but managed via the standalone
+    # proxmox_virtual_environment_acl resource. Ignore it here to prevent
+    # Terraform from revoking permissions during apply.
+    ignore_changes = [acl]
+  }
+}
+
+resource "proxmox_virtual_environment_user_token" "terraform" {
+  user_id              = proxmox_virtual_environment_user.terraform.user_id
+  token_name           = "terraform-token"
+  privileges_separation = false
+  comment              = "Terraform API token"
+}
+
+resource "proxmox_virtual_environment_acl" "terraform_admin" {
+  path    = "/"
+  user_id = proxmox_virtual_environment_user.terraform.user_id
+  role_id = "Administrator"
+}

--- a/proxmox/terraform/variables.tf
+++ b/proxmox/terraform/variables.tf
@@ -1,0 +1,52 @@
+variable "proxmox_endpoint" {
+  description = "Proxmox API endpoint URL (uses Tailscale hostname)"
+  type        = string
+  default     = "https://jonbonas:8006"
+}
+
+variable "proxmox_api_token" {
+  description = "Proxmox API token (format: user@realm!token-name=secret)"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_node" {
+  description = "Proxmox node name"
+  type        = string
+  default     = "jonbonas"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access"
+  type        = string
+}
+
+variable "vm_user" {
+  description = "Default user for cloud-init VMs"
+  type        = string
+  default     = "dixneuf19"
+}
+
+variable "k8s_worker_count" {
+  description = "Number of Kubernetes worker VMs to create"
+  type        = number
+  default     = 2
+}
+
+variable "k8s_worker_cores" {
+  description = "Number of CPU cores per K8s worker VM"
+  type        = number
+  default     = 4
+}
+
+variable "k8s_worker_memory" {
+  description = "Memory in MB per K8s worker VM"
+  type        = number
+  default     = 8192
+}
+
+variable "k8s_worker_disk_size" {
+  description = "Disk size in GB per K8s worker VM"
+  type        = number
+  default     = 50
+}

--- a/proxmox/terraform/versions.tf
+++ b/proxmox/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.14.5"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "= 0.95.0"
+    }
+  }
+}

--- a/proxmox/terraform/vms.tf
+++ b/proxmox/terraform/vms.tf
@@ -1,0 +1,82 @@
+# # =============================================
+# # Kubernetes Worker VMs
+# # Cloud-init Ubuntu VMs on fastpool for K8s workloads
+# # =============================================
+
+# resource "proxmox_virtual_environment_vm" "k8s_worker" {
+#   count     = var.k8s_worker_count
+#   name      = "k8s-worker-${count.index + 1}"
+#   node_name = var.proxmox_node
+#   vm_id     = 200 + count.index
+
+#   # Machine type
+#   machine = "q35"
+#   bios    = "ovmf"
+
+#   # Resources
+#   cpu {
+#     cores = var.k8s_worker_cores
+#     type  = "host"
+#   }
+
+#   memory {
+#     dedicated = var.k8s_worker_memory
+#   }
+
+#   # Boot disk from cloud image on fastpool
+#   disk {
+#     datastore_id = proxmox_virtual_environment_storage_zfspool.fastpool.id
+#     file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+#     interface    = "virtio0"
+#     size         = var.k8s_worker_disk_size
+#     discard      = "on"
+#   }
+
+#   # EFI disk
+#   efi_disk {
+#     datastore_id = proxmox_virtual_environment_storage_zfspool.fastpool.id
+#   }
+
+#   # Network
+#   network_device {
+#     bridge = "vmbr0"
+#     model  = "virtio"
+#   }
+
+#   # Cloud-init configuration
+#   initialization {
+#     ip_config {
+#       ipv4 {
+#         address = "192.168.1.${40 + count.index}/24"
+#         gateway = "192.168.1.1"
+#       }
+#     }
+
+#     dns {
+#       servers = ["192.168.1.1", "1.1.1.1"]
+#     }
+
+#     user_account {
+#       username = var.vm_user
+#       keys     = [var.ssh_public_key]
+#     }
+#   }
+
+#   # QEMU guest agent
+#   agent {
+#     enabled = true
+#   }
+
+#   # Start on boot
+#   on_boot = true
+
+#   # Don't start automatically after creation (we'll start when ready)
+#   started = false
+
+#   lifecycle {
+#     ignore_changes = [
+#       # Ignore changes to started state (managed manually)
+#       started,
+#     ]
+#   }
+# }

--- a/scripts/tailscale-hostmap.py
+++ b/scripts/tailscale-hostmap.py
@@ -1,2 +1,213 @@
 #!/bin/env python3
 # Source: https://github.com/mxbi/tailscale-hostmap (main)
+"""Map tailscale hosts into /etc/hosts."""
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import typing
+from dataclasses import dataclass
+from pathlib import Path
+
+args = None
+HOSTS_BEGIN = "# tailscale-hostmap begin"
+HOSTS_END = "# tailscale-hostmap end"
+
+
+def is_ip4(addr: str) -> bool:
+    """Check for ip4 address."""
+    # tailscale all start with 100
+    return addr.startswith("100")
+
+
+def is_valid_host(hostname: str) -> bool:
+    """Check host name is valid."""
+    return hostname != "device-of-shared-to-user"
+
+
+def is_valid_addr(addr: str) -> bool:
+    """Check address is valid."""
+    if args.ip4 or args.ip6:
+        return args.ip4 if is_ip4(addr) else args.ip6
+    else:
+        return True
+
+@dataclass
+class PeerInfo:
+    """Information about tailscale peers."""
+
+    host: str
+    addr: str
+    comments: typing.List[str]
+
+    def hostname(self) -> str:
+        """Compose hostname with domain extension."""
+        return f"{self.host}.{args.domain}" if args.domain else self.host
+
+    def comment_str(self) -> str:
+        """Flatten comments into string."""
+        return "# {}".format(", ".join(self.comments)) if self.comments else ""
+
+    def host_line(self, fmt_str: str) -> str:
+        """Format as host line."""
+        return fmt_str.format(self.addr, self.hostname(), self.comment_str())
+
+    def is_valid(self) -> bool:
+        """Check if peer matches spec."""
+        return is_valid_host(self.host) and is_valid_addr(self.addr)
+
+
+def valid_peers(
+    peers: typing.List[PeerInfo],
+) -> typing.Generator[typing.Union[PeerInfo, None], None, None]:
+    """Generate valid peers."""
+    return (pr for pr in peers if pr.is_valid())
+
+
+def tailscale_peers() -> typing.List[PeerInfo]:
+    """Get peer info from tailscale."""
+    # query tailscale
+    status = json.loads(
+        subprocess.check_output([args.ts_binary, "status", "--json"])
+    )
+
+    # To check for shared machines, we exclude any machines owned by other users
+    # This could be an issue with team tailscale, but I can't test it right now, so let me know.
+    self_uid = status["Self"]["UserID"]
+
+    def valid_status() -> typing.Generator[
+        typing.Dict[str, typing.Any], None, None
+    ]:
+        """Iterate valid peers."""
+        return (
+            pr
+            for pr in status["Peer"].values()
+            if args.include_shared or pr["UserID"] == self_uid
+        )
+
+    peers = []
+    # run my peers
+    for peer in valid_status():
+        peer_uid = peer["UserID"]
+
+        # ip4 and ip6...
+        peers.extend(
+            PeerInfo(
+                peer["HostName"].lower(),
+                ipaddr,
+                ["shared"] if peer_uid != self_uid else [],
+            )
+            for ipaddr in peer["TailscaleIPs"]
+        )
+
+    return peers
+
+def format_hosts_lines(peers: typing.List[PeerInfo]) -> typing.List[str]:
+    """Format peers into lines for /etc/hosts."""
+    # line-up columns
+    if len(list(valid_peers(peers))) == 0:
+        raise Exception("No valid peers found.")
+
+    maxaddr = max(len(peer.addr) for peer in valid_peers(peers))
+    maxhost = max(len(peer.hostname()) for peer in valid_peers(peers))
+    fmt_str = f"{{:<{maxaddr}}}\t{{:<{maxhost}}}\t{{}}"
+
+    return (
+        [
+            HOSTS_BEGIN,
+            f"# modified {datetime.datetime.now().isoformat()}",
+        ]
+        + [peer.host_line(fmt_str) for peer in valid_peers(peers)]
+        + [HOSTS_END]
+    )
+
+
+def update_hosts(hosts_lines: typing.List[str]) -> typing.List[str]:
+    """Update hosts file with tailscale peers."""
+    # read old file
+    old_etc_hosts = Path(args.hosts_file).read_text(encoding="utf-8")
+
+    # remove old entries
+    new_etc_hosts = re.sub(
+        rf"{HOSTS_BEGIN}.*{HOSTS_END}",
+        "",
+        old_etc_hosts,
+        flags=re.S,
+    )
+
+    # add new entries
+    new_etc_hosts += "\n".join(hosts_lines)
+
+    # stage "new" file
+    new_file = f"{args.hosts_file}.tailscale-hostmap"
+    with open(new_file, "w", encoding="utf-8") as f_hostmap:
+        f_hostmap.write(new_etc_hosts)
+
+    # BIG - mv "new" file over "old" file
+    # RACE CONDITION - POSSIBLE DATA LOSS
+    os.rename(new_file, args.hosts_file)
+
+    return hosts_lines
+
+
+def main(argv: typing.List[str] = None) -> int:
+    """Run program."""
+    if not argv:
+        argv = sys.argv
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--domain",
+        default=False,
+        help="The domain to append to the hostname. For example, `pi` becomes `pi.ts` when domain=`ts`. Defaults to no domain",
+    )
+    parser.add_argument(
+        "-s",
+        "--include-shared",
+        default=False,
+        action="store_true",
+        help="Add this flag to also include shared machines in DNS",
+    )
+    parser.add_argument(
+        "--ts-binary",
+        default="/usr/bin/tailscale",
+        help="The location of the tailscale binary to call. Defaults to /usr/bin/tailscale",
+    )
+    parser.add_argument(
+        "-ip4",
+        "--ip4",
+        default=False,
+        action="store_true",
+        help="Add this flag to limit processing to ip4 addresses",
+    )
+    parser.add_argument(
+        "-ip6",
+        "--ip6",
+        default=False,
+        action="store_true",
+        help="Add this flag to limit processing to ip6 addresses",
+    )
+    parser.add_argument(
+        "--hosts-file",
+        default="/etc/hosts",
+        help="The location of the hosts file to update. Defaults to /etc/hosts",
+    )
+    global args
+    args = parser.parse_args()
+
+    # do the update
+    hosts_lines = update_hosts(format_hosts_lines(tailscale_peers()))
+
+    # report status
+    me = Path(argv[0]).resolve()
+    print("\n".join(hosts_lines))
+    print("Add this line to /etc/crontab to run this script automatically:")
+    print(f"*/5 * * * * /usr/bin/python3 {me} --domain ts -s")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Ansible playbooks** for bootstrapping Proxmox (packages, Tailscale, Terraform API token) and configuring all ZFS pools/datasets (rpool tuning, fastpool on NVMe, tank RAIDZ1 on HDDs)
- **Terraform** (bpg/proxmox v0.95.0) for managing Proxmox API resources: storage backends, users/ACLs, cloud-init templates, with remote state on Scaleway Object Storage
- **Documentation**: step-by-step setup guide (`proxmox/README.md`) and ZFS architecture explainer with diagrams (`proxmox/ZFS.md`)
- **Bugfix**: tailscale-hostmap download pipe was broken on macOS (head/tail buffer issue), replaced with awk
- **DX**: Scaleway S3 credentials auto-loaded in `.envrc` via `scw config`, Makefile targets for the full setup flow

## Architecture

```
Proxmox Install (manual) -> Post-install script (make proxmox-post-install)
  -> Ansible bootstrap (make proxmox-bootstrap) [local IP]
  -> Tailscale join (manual) + make tailscale-hosts
  -> Ansible ZFS (make proxmox-zfs) [Tailscale]
  -> Terraform apply [Tailscale]
```

3 ZFS pools: `rpool` (OS, NVMe 1TB), `fastpool` (VMs, NVMe 2TB), `tank` (bulk, 4x12TB RAIDZ1)

## Test plan

- [x] `terraform init` succeeds with Scaleway S3 backend
- [x] `terraform plan` shows clean plan (imports + creates, no destroys)
- [x] `terraform apply` completes (storage imports, user/token/ACL imports, cloud image download)
- [ ] Full end-to-end after Proxmox reinstall (ansible bootstrap -> zfs -> terraform)

Made with [Cursor](https://cursor.com)